### PR TITLE
Added option: install-provisional-version

### DIFF
--- a/src/Smrtr/MysqlVersionControl/TeardownCommand.php
+++ b/src/Smrtr/MysqlVersionControl/TeardownCommand.php
@@ -27,7 +27,7 @@ class TeardownCommand extends Command
     {
         $this
             ->setName($this->env)
-            ->setDescription('Install the '.$this->env.' versions')
+            ->setDescription('Tear down the '.$this->env.' database tables')
             ->addArgument(
                 'mysqlbin',
                 InputArgument::OPTIONAL,

--- a/src/Smrtr/MysqlVersionControl/UpCommand.php
+++ b/src/Smrtr/MysqlVersionControl/UpCommand.php
@@ -189,6 +189,8 @@ class UpCommand extends Command
                 $provisionalVersion = self::DEFAULT_PROVISIONAL_VERSION_NAME;
             }
 
+            $output->writeln('Provisional version: '.$provisionalVersion);
+
             $path = $versionsPath.DIRECTORY_SEPARATOR.$provisionalVersion;
             if (is_readable($path) && is_dir($path)) {
 

--- a/src/Smrtr/MysqlVersionControl/UpCommand.php
+++ b/src/Smrtr/MysqlVersionControl/UpCommand.php
@@ -56,7 +56,7 @@ class UpCommand extends Command
             )
             ->addOption(
                 'install-provisional-version',
-                'p',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 'Install a provisional version which may still be in development and is not final. '.PHP_EOL.
                 'The provisional version is in a dir named \''.self::DEFAULT_PROVISIONAL_VERSION_NAME.'\' by default; '.


### PR DESCRIPTION
Added capability to install a provisional version that is in active development.

Use the `--install-provisional-version` flag to install a provisional version. By default this will make the up command look in `<project_root>/db/versions/provisional` for files and run it as if it were the latest version.

To override the name of the directory containing the provisional version you can supply a value to the option. E.g. `--install-provisional-version=head` would make the installer look in `<project_root>/db/versions/head`.

The default behaviour is not to install a provisional version.